### PR TITLE
app.scss is missing the hello-ionic import

### DIFF
--- a/www/app/app.scss
+++ b/www/app/app.scss
@@ -29,5 +29,7 @@ $colors: (
 
 // Import your Sass files here
 // ---------------------------------
-@import "item-details/item-details";
+@import "item-details/item-details",
+        //"list/list",
+        "hello-ionic/hello-ionic";
 


### PR DESCRIPTION
The styles in hello-ionic/hello-ionic.scss are not getting picked up because of the missing import.
Currently list.scss is empty, hence the reason I have it commented out.  I'm not sure what the convention is... to import it anyway or to not import it.
