### PR TITLE
Type for pages.component fixed

### DIFF
--- a/app/app.ts
+++ b/app/app.ts
@@ -10,7 +10,7 @@ import {ListPage} from './pages/list/list';
 class MyApp {
   // make HelloIonicPage the root (or first) page
   rootPage: any = HelloIonicPage;
-  pages: Array<{title: string, component: Type}>;
+  pages: Array<{title: string, component: any}>;
 
   constructor(private app: IonicApp, private platform: Platform) {
     this.initializeApp();


### PR DESCRIPTION
Specifying `any` type to get rid of build error `ERROR in [default] /.../app/app.ts:13:42 Cannot find name 'Type'`
