### PR TITLE
fix: change 'swipe-back-enabled' to 'swipeBackEnabled'

### DIFF
--- a/app/app.html
+++ b/app/app.html
@@ -14,4 +14,4 @@
 
 </ion-menu>
 
-<ion-nav [root]="rootPage" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>


### PR DESCRIPTION
`<ion-nav>` accepts `swipeBackEnabled`, not `swipe-back-enabled`.

Related issue: https://github.com/driftyco/ionic/issues/5653

Also pull-requested to [ionic-site](https://github.com/driftyco/ionic-site/pull/715)
