### PR TITLE
fix(page): page specific scss not included

### DIFF
--- a/src/pages/hello-ionic/hello-ionic.scss
+++ b/src/pages/hello-ionic/hello-ionic.scss
@@ -1,4 +1,4 @@
-.hello-ionic-page {
+hello-ionic-page {
 
   p {
     margin: 20px 0;

--- a/src/pages/hello-ionic/hello-ionic.ts
+++ b/src/pages/hello-ionic/hello-ionic.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 
 @Component({
+  selector: 'hello-ionic-page',
   templateUrl: 'hello-ionic.html'
 })
 export class HelloIonicPage {

--- a/src/pages/item-details/item-details.scss
+++ b/src/pages/item-details/item-details.scss
@@ -1,4 +1,4 @@
-.item-details-page {
+item-details-page {
 
   div.selection {
     font-size: 22px;

--- a/src/pages/item-details/item-details.ts
+++ b/src/pages/item-details/item-details.ts
@@ -4,6 +4,7 @@ import { NavController, NavParams } from 'ionic-angular';
 
 
 @Component({
+  selector: 'item-details-page',
   templateUrl: 'item-details.html'
 })
 export class ItemDetailsPage {

--- a/src/pages/list/list.scss
+++ b/src/pages/list/list.scss
@@ -1,3 +1,3 @@
-.list-page {
+list-page {
 
 }

--- a/src/pages/list/list.ts
+++ b/src/pages/list/list.ts
@@ -6,6 +6,7 @@ import { ItemDetailsPage } from '../item-details/item-details';
 
 
 @Component({
+  selector: 'list-page',
   templateUrl: 'list.html'
 })
 export class ListPage {


### PR DESCRIPTION
The page specific scss is not included because of a migration issue described in [Migration Guide](https://github.com/driftyco/ionic/blob/master/CHANGELOG.md#modifying-your-existing-project) at point 36.

It's especially easy to miss that in addition to adding the "selector" the prefix "dot" must be removed if one updates from ionic2 beta to a release candidate.