### PR TITLE
Remove obsolete code for displaying selected item from list component

### DIFF
--- a/src/pages/list/list.html
+++ b/src/pages/list/list.html
@@ -17,7 +17,4 @@
       </div>
     </button>
   </ion-list>
-  <div *ngIf="selectedItem" padding>
-    You navigated here from <b>{{selectedItem.title}}</b>
-  </div>
 </ion-content>

--- a/src/pages/list/list.ts
+++ b/src/pages/list/list.ts
@@ -10,14 +10,10 @@ import { ItemDetailsPage } from '../item-details/item-details';
   templateUrl: 'list.html'
 })
 export class ListPage {
-  selectedItem: any;
   icons: string[];
   items: Array<{title: string, note: string, icon: string}>;
 
   constructor(public navCtrl: NavController, public navParams: NavParams) {
-    // If we navigated to this page, we will have an item available as a nav param
-    this.selectedItem = navParams.get('item');
-
     this.icons = ['flask', 'wifi', 'beer', 'football', 'basketball', 'paper-plane',
     'american-football', 'boat', 'bluetooth', 'build'];
 


### PR DESCRIPTION
The `selectedItem` is now shown in a separate `item-details` page and hence never shown on the original `list` page.
Removing `selectedItem` related code from the `list.ts` and `list.html` files.