### PR TITLE
set rootPage to class name, not string

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,7 +16,7 @@ export class MyApp {
   @ViewChild(Nav) nav: Nav;
 
   // make HelloIonicPage the root (or first) page
-  rootPage = 'HelloIonicPage';
+  rootPage = HelloIonicPage;
   pages: Array<{title: string, component: any}>;
 
   constructor(


### PR DESCRIPTION
Without the above change, the following errors occur when loading a tutorial project:
Failed to navigate:  undefined
ERROR Error: Uncaught (in promise): invalid link: HelloIonicPage